### PR TITLE
Add Wikipedia search engine

### DIFF
--- a/letmebot.php
+++ b/letmebot.php
@@ -55,6 +55,12 @@ function inline_response($query_id, $query_text) {
 			'thumb_url' => 'https://cdn.ecosia.org/assets/images/png/apple-touch-icon.png',
 		],
 		[
+			'ident' => 'wiki',
+			'url' => 'https://en.wikipedia.org/wiki/Special:Search/' . urlencode($query_text),
+			'name' = '📚 Wikipedia',
+			'thumb_url' => 'https://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png',
+		],
+		[
 			'ident' => 'Wikihow',
 			'url' => 'https://en.wikihow.com/wikiHowTo?search=' . urlencode($query_text),
 			'name' => '📖 Wikihow',


### PR DESCRIPTION
Wikipedia provides a search string for browsers which was taken as a
url:
https://en.wikipedia.org/wiki/Help:Searching_from_a_web_browser
https://en.wikipedia.org/wiki/Special:Search/Type_What_You_Wanna_Find_Instead_Of_Me

I used English version.

Logo sized 200px x 200px was taken from Wikimedia Commons:
https://commons.wikimedia.org/wiki/Category:Wikipedia_logo,_v2
https://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png

Books were chosen as Emoji but it's not the same as in Wikihow, ud or
telethondocs.